### PR TITLE
Add taxa from PRAs in reference file

### DIFF
--- a/references/modelling_species.tsv
+++ b/references/modelling_species.tsv
@@ -3,41 +3,81 @@ Acer negundo	plants	Plantae	3189866	ACCEPTED
 Ailanthus altissima	plants	Plantae	3190653	ACCEPTED
 Akebia quinata	plants	Plantae	3033965	ACCEPTED
 Amelanchier lamarckii	plants	Plantae	3024109	ACCEPTED
+Aix galericulata	birds	Animalia	2498388	ACCEPTED
+Aix sponsa	birds	Animalia	2498387	ACCEPTED
+Anas sibilatrix	birds	Animalia	2498110	ACCEPTED
 Astacus leptodactylus	crustaceans	Animalia	4417551	SYNONYM
 Azolla filiculoides	aquatic plants	Plantae	2650107	ACCEPTED
+Balanus tintinnabulum	crustaceans	Animalia	2115692	ACCEPTED
+Callinectes sapidus	crustaceans	Animalia	2225646	ACCEPTED
+Callosciurus prevostii	mammals	Animalia	2437397	ACCEPTED
+Campylopus introflexus	plants	Plantae	5281901	ACCEPTED
+Caprella mutica	crustaceans	Animalia	5178057	ACCEPTED
 Carpobrotus edulis	plants	Plantae	3084842	ACCEPTED
 Cervus nippon	mammals	Animalia	2440954	ACCEPTED
 Chelydra serpentina	reptiles	Animalia	2441905	ACCEPTED
+Cornus sanguinea australis	plants	Plantae	3663237	ACCEPTED
+Cornus sanguinea hungarica	plants	Plantae	8421432	ACCEPTED
+Cornus sericea	plants	Plantae	3082244	ACCEPTED
+Corbicula fluminalis	mollusca	Animalia	5189032	ACCEPTED
+Corbicula fluminea	mollusca	Animalia	8190231	ACCEPTED
 Coturnix japonica	birds	Animalia	2474162	ACCEPTED
 Crassula helmsii	aquatic plants	Plantae	8035075	ACCEPTED
 Cyperus eragrostis	plants	Plantae	2715482	ACCEPTED
+Cyperus esculentus	plants	Plantae	2716226	ACCEPTED
+Dolichotis patagonum	mammals	Animalia	2437619	ACCEPTED
 Dama dama	mammals	Animalia	5220136	ACCEPTED
+Deroceras invadens	mollusca	Animalia	8745918	ACCEPTED
 Egeria densa	aquatic plants	Plantae	5329260	ACCEPTED
 Elaeagnus angustifolia	plants	Plantae	3039269	ACCEPTED
 Elaphe schrenckii	reptiles	Animalia	2458438	ACCEPTED
+Ensis directus	mollusca	Animalia	2287249	ACCEPTED
+Eriocheir sinensis	crustaceans	Animalia	2225776	ACCEPTED
 Fraxinus pennsylvanica	plants	Plantae	3172348	ACCEPTED
+Hemigrapsus sanguineus	crustaceans	Animalia	2225772	ACCEPTED
+Hemigrapsus takanoi	crustaceans	Animalia	4382841	ACCEPTED
+Impatiens balfourii	plants	Plantae	2891783	ACCEPTED
 Impatiens capensis	plants	Plantae	2891774	ACCEPTED
+Impatiens glandulifera	plants	Plantae	2891770	ACCEPTED
+Impatiens parviflora	plants	Plantae	2891782	ACCEPTED
 Koenigia polystachya	plants	Plantae	8848208	ACCEPTED
 Leiothrix lutea	birds	Animalia	5231398	ACCEPTED
 Leuciscus aspius	fish	Animalia	5851603	ACCEPTED
 Lycium barbarum	plants	Plantae	2928835	ACCEPTED
+Magallana gigas	mollusca	Animalia	7820753	ACCEPTED
+Massylaea vermiculata	mollusca	Animalia	9291405	ACCEPTED
 Mephitis mephitis	mammals	Animalia	5219380	ACCEPTED
 Mimulus guttatus Fisch. ex DC.	plants	Plantae	6070603	SYNONYM
 Misgurnus anguillicaudatus	fish	Animalia	2367919	ACCEPTED
+Mnemiopsis leidyi	comb jellies	Animalia	2501248	ACCEPTED
 Myiopsitta monachus	birds	Animalia	2479407	ACCEPTED
+Mytilopsis leucophaeata	mollusca	Animalia	2287076	ACCEPTED
 Neogobius melanostomus	fish	Animalia	2379089	ACCEPTED
 Neovison vison	mammals	Animalia	2433652	ACCEPTED
 Orthriophis taeniurus	reptiles	Animalia	2455523	ACCEPTED
+Palaemon macrodactylus	crustaceans	Animalia	2224970	ACCEPTED
+Pelophylax bedriagae	amphibians	Animalia	2426640	ACCEPTED
 Pelophylax ridibundus	amphibians	Animalia	2426661	ACCEPTED
 Phytolacca americana	plants	Plantae	3084015	ACCEPTED
 Pimephales promelas	fish	Animalia	2367742	ACCEPTED
 Podarcis siculus	reptiles	Animalia	9185677	ACCEPTED
 Pontederia cordata	plants	Plantae	2766030	ACCEPTED
+Potamopyrgus antipodarum	mollusca	Animalia	5192470	ACCEPTED
 Pycnonotus cafer	birds	Animalia	2486131	ACCEPTED
+Rhithropanopeus harrisii	mollusca	Animalia	2227663	ACCEPTED
 Rhus typhina	plants	Plantae	3190538	ACCEPTED
+Rosa glauca	plants	Plantae	3003709	ACCEPTED
 Rosa multiflora	plants	Plantae	3003244	ACCEPTED
 Rudbeckia laciniata	plants	Plantae	3114229	ACCEPTED
+Rubus laciniatus	plants	Plantae	2992543	ACCEPTED
+Rubus spectabilis	plants	Plantae	2993761	ACCEPTED
 Sagittaria latifolia	aquatic plants	Plantae	5328909	ACCEPTED
+Sinanodonta woodiana	mollusca	Animalia	4559541	ACCEPTED
 Spiraea alba	plants	Plantae	7787813	ACCEPTED
+Symphyotrichum lanceolatum	plants	Plantae	9202318	ACCEPTED
+Symphyotrichum novae-angliae	plants	Plantae	3151618	ACCEPTED
+Symphyotrichum novi-belgii	plants	Plantae	3151558	ACCEPTED
 Tamiasciurus hudsonicus	mammals	Animalia	2437282	ACCEPTED
 Triturus carnifex	amphibians	Animalia	2431887	ACCEPTED
+Vaccinium corymbosum	plants	Plantae	2882849	ACCEPTED
+Vaccinium macrocarpum	plants	Plantae	7777960	ACCEPTED


### PR DESCRIPTION
This PR fixes #25.

@qgroom, @timadriaens, I assigned value `comb jellies` to field `checklist_group` for _Mnemiopsis leidyi_ (see [references/modelling_species.tsv#L52](https://github.com/trias-project/occ-cube-alien/blob/udpate_modelling_taxa_file/references/modelling_species.tsv#L52)). Please confirm it or change it. It's the only jelly in the modelling/PRA list of species.